### PR TITLE
feat: remove hard dependency on fast utils

### DIFF
--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/Cache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/Cache.kt
@@ -2,6 +2,8 @@ package dev.openrune.filesystem
 
 import java.nio.file.Path
 
+internal typealias MapFactory = () -> MutableMap<Int, Int>
+
 interface Cache {
 
     val versionTable: ByteArray

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
@@ -39,6 +39,7 @@ interface CacheLoader {
         indexCount: Int,
         versionTable: VersionTableBuilder? = null,
         xteas: Map<Int, IntArray>? = null,
-        threadUsage: Double = 1.0
+        threadUsage: Double = 1.0,
+        mapFactory: () -> MutableMap<Int, Int> = { mutableMapOf() }
     ): Cache
 }

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
@@ -11,7 +11,7 @@ interface CacheLoader {
     fun load(
         properties: Properties,
         xteas: Map<Int, IntArray>? = null,
-        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
+        mapFactory: MapFactory = ::createNameMap
     ): Cache {
         val cachePath = properties.getProperty("cachePath")
         val threadUsage = properties.getProperty("threadUsage", "1.0").toDouble()
@@ -22,7 +22,7 @@ interface CacheLoader {
         path: String,
         xteas: Map<Int, IntArray>? = null,
         threadUsage: Double = 1.0,
-        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
+        mapFactory: MapFactory = ::createNameMap
     ): Cache {
         val mainFile = File(path, "${FileCache.CACHE_FILE_NAME}.dat2")
         if (!mainFile.exists()) {
@@ -49,7 +49,7 @@ interface CacheLoader {
         versionTable: VersionTableBuilder? = null,
         xteas: Map<Int, IntArray>? = null,
         threadUsage: Double = 1.0,
-        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
+        mapFactory: MapFactory = ::createNameMap
     ): Cache
 
     private fun createNameMap(): MutableMap<Int, Int> {

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/CacheLoader.kt
@@ -8,13 +8,22 @@ import java.util.*
 
 interface CacheLoader {
 
-    fun load(properties: Properties, xteas: Map<Int, IntArray>? = null): Cache {
+    fun load(
+        properties: Properties,
+        xteas: Map<Int, IntArray>? = null,
+        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
+    ): Cache {
         val cachePath = properties.getProperty("cachePath")
         val threadUsage = properties.getProperty("threadUsage", "1.0").toDouble()
-        return load(cachePath, threadUsage = threadUsage)
+        return load(cachePath, threadUsage = threadUsage, mapFactory = mapFactory)
     }
 
-    fun load(path: String, xteas: Map<Int, IntArray>? = null, threadUsage: Double = 1.0): Cache {
+    fun load(
+        path: String,
+        xteas: Map<Int, IntArray>? = null,
+        threadUsage: Double = 1.0,
+        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
+    ): Cache {
         val mainFile = File(path, "${FileCache.CACHE_FILE_NAME}.dat2")
         if (!mainFile.exists()) {
             throw FileNotFoundException("Main file not found at '${mainFile.absolutePath}'.")
@@ -27,7 +36,7 @@ interface CacheLoader {
         val index255 = RandomAccessFile(index255File, "r")
         val indexCount = index255.length().toInt() / ReadOnlyCache.INDEX_SIZE
         val versionTable = VersionTableBuilder(indexCount)
-        return load(path, mainFile, main, index255File, index255, indexCount, versionTable, xteas, threadUsage)
+        return load(path, mainFile, main, index255File, index255, indexCount, versionTable, xteas, threadUsage, mapFactory)
     }
 
     fun load(
@@ -40,6 +49,16 @@ interface CacheLoader {
         versionTable: VersionTableBuilder? = null,
         xteas: Map<Int, IntArray>? = null,
         threadUsage: Double = 1.0,
-        mapFactory: () -> MutableMap<Int, Int> = { mutableMapOf() }
+        mapFactory: () -> MutableMap<Int, Int> = ::createNameMap
     ): Cache
+
+    private fun createNameMap(): MutableMap<Int, Int> {
+        return try {
+            val fastutilClass = Class.forName("it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap")
+            val constructor = fastutilClass.getConstructor(Int::class.java)
+            constructor.newInstance(16384) as MutableMap<Int, Int>
+        } catch (e: ClassNotFoundException) {
+            LinkedHashMap(16384)
+        }
+    }
 }

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/FileCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/FileCache.kt
@@ -14,8 +14,9 @@ class FileCache(
     private val index255: RandomAccessFile,
     private val indexes: Array<RandomAccessFile?>,
     indexCount: Int,
-    val xteas: Map<Int, IntArray>?
-) : ReadOnlyCache(indexCount) {
+    val xteas: Map<Int, IntArray>?,
+    mapFactory: () -> MutableMap<Int, Int>
+) : ReadOnlyCache(indexCount, mapFactory) {
 
     private val dataCache = object : LinkedHashMap<Int, Array<ByteArray?>>(16, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, Array<ByteArray?>>): Boolean {
@@ -76,7 +77,8 @@ class FileCache(
             indexCount: Int,
             versionTable: VersionTableBuilder?,
             xteas: Map<Int, IntArray>?,
-            threadUsage: Double
+            threadUsage: Double,
+            mapFactory: () -> MutableMap<Int, Int>
         ): Cache {
             val length = mainFile.length()
             val context = DecompressionContext()
@@ -84,7 +86,7 @@ class FileCache(
                 val file = File(path, "$CACHE_FILE_NAME.idx$indexId")
                 if (file.exists()) RandomAccessFile(file, "r") else null
             }
-            val cache = FileCache(main, index255, indices, indexCount, xteas)
+            val cache = FileCache(main, index255, indices, indexCount, xteas, mapFactory)
             for (indexId in 0 until indexCount) {
                 cache.archiveData(context, main, length, index255, indexId, versionTable)
             }

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/FileCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/FileCache.kt
@@ -15,7 +15,7 @@ class FileCache(
     private val indexes: Array<RandomAccessFile?>,
     indexCount: Int,
     val xteas: Map<Int, IntArray>?,
-    mapFactory: () -> MutableMap<Int, Int>
+    mapFactory: MapFactory
 ) : ReadOnlyCache(indexCount, mapFactory) {
 
     private val dataCache = object : LinkedHashMap<Int, Array<ByteArray?>>(16, 0.75f, true) {
@@ -78,7 +78,7 @@ class FileCache(
             versionTable: VersionTableBuilder?,
             xteas: Map<Int, IntArray>?,
             threadUsage: Double,
-            mapFactory: () -> MutableMap<Int, Int>
+            mapFactory: MapFactory
         ): Cache {
             val length = mainFile.length()
             val context = DecompressionContext()

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/MemoryCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/MemoryCache.kt
@@ -19,7 +19,7 @@ import java.io.RandomAccessFile
  */
 class MemoryCache(
     indexCount: Int,
-    mapFactory: () -> MutableMap<Int, Int>
+    mapFactory: MapFactory
 ) : ReadOnlyCache(indexCount, mapFactory) {
 
     val data: Array<Array<Array<ByteArray?>?>?> = arrayOfNulls(indexCount)
@@ -58,7 +58,7 @@ class MemoryCache(
             versionTable: VersionTableBuilder?,
             xteas: Map<Int, IntArray>?,
             threadUsage: Double,
-            mapFactory: () -> MutableMap<Int, Int>
+            mapFactory: MapFactory
         ): Cache {
             val cache = MemoryCache(indexCount, mapFactory)
             val processors = (Runtime.getRuntime().availableProcessors() * threadUsage).toInt().coerceAtLeast(1)

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/MemoryCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/MemoryCache.kt
@@ -17,7 +17,10 @@ import java.io.RandomAccessFile
  * reading dynamic map regions in MapDefinitions.
  * It is however very useful for integration tests to speed world resetting.
  */
-class MemoryCache(indexCount: Int) : ReadOnlyCache(indexCount) {
+class MemoryCache(
+    indexCount: Int,
+    mapFactory: () -> MutableMap<Int, Int>
+) : ReadOnlyCache(indexCount, mapFactory) {
 
     val data: Array<Array<Array<ByteArray?>?>?> = arrayOfNulls(indexCount)
     val sectors: Array<Array<ByteArray?>?> = arrayOfNulls(indexCount)
@@ -54,9 +57,10 @@ class MemoryCache(indexCount: Int) : ReadOnlyCache(indexCount) {
             indexCount: Int,
             versionTable: VersionTableBuilder?,
             xteas: Map<Int, IntArray>?,
-            threadUsage: Double
+            threadUsage: Double,
+            mapFactory: () -> MutableMap<Int, Int>
         ): Cache {
-            val cache = MemoryCache(indexCount)
+            val cache = MemoryCache(indexCount, mapFactory)
             val processors = (Runtime.getRuntime().availableProcessors() * threadUsage).toInt().coerceAtLeast(1)
             newFixedThreadPoolContext(processors, "cache-loader").use { dispatcher ->
                 runBlocking(dispatcher) {

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/ReadOnlyCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/ReadOnlyCache.kt
@@ -6,19 +6,21 @@ import dev.openrune.filesystem.util.readInt
 import dev.openrune.filesystem.util.readUnsignedByte
 import dev.openrune.filesystem.util.secure.VersionTableBuilder
 import io.github.oshai.kotlinlogging.KotlinLogging
-import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 
 /**
  * [Cache] which efficiently stores information about its indexes, archives and files.
  */
-abstract class ReadOnlyCache(indexCount: Int) : Cache {
+abstract class ReadOnlyCache(
+    indexCount: Int,
+    mapFactory: () -> MutableMap<Int, Int>
+) : Cache {
     val indices: IntArray = IntArray(indexCount) { it }
     val archives: Array<IntArray?> = arrayOfNulls(indexCount)
     val fileCounts: Array<IntArray?> = arrayOfNulls(indexCount)
     val files: Array<Array<IntArray?>?> = arrayOfNulls(indexCount)
-    private val hashes: MutableMap<Int, Int> = Int2IntOpenHashMap(16384)
+    private val hashes: MutableMap<Int, Int> = mapFactory()
 
     override lateinit var versionTable: ByteArray
 

--- a/filesystem/src/main/kotlin/dev/openrune/filesystem/ReadOnlyCache.kt
+++ b/filesystem/src/main/kotlin/dev/openrune/filesystem/ReadOnlyCache.kt
@@ -14,7 +14,7 @@ import java.nio.ByteBuffer
  */
 abstract class ReadOnlyCache(
     indexCount: Int,
-    mapFactory: () -> MutableMap<Int, Int>
+    mapFactory: MapFactory
 ) : Cache {
     val indices: IntArray = IntArray(indexCount) { it }
     val archives: Array<IntArray?> = arrayOfNulls(indexCount)


### PR DESCRIPTION
A factory type alias was created which is used to check if fast utils is on classpath. If not, the factory just creates a LinkedHashMap with the same size. This is the backing implementation of the kotlin mutableMapOf()